### PR TITLE
WIP: Enable being above fullscreen

### DIFF
--- a/src/windows/windows.js
+++ b/src/windows/windows.js
@@ -82,8 +82,7 @@ exports.createFullscreenWindow = () => {
     return
   }
 
-  const primaryDisplay = electron.screen.getPrimaryDisplay()
-  const { width, height } = primaryDisplay.bounds
+  const { width, height } = electron.screen.getPrimaryDisplay().workAreaSize
   fullscreenWindow = createAlwaysOnTopFullscreenInterruptingWindow({
     width,
     height,

--- a/src/windows/windows.js
+++ b/src/windows/windows.js
@@ -1,4 +1,5 @@
 const electron = require('electron')
+const { app } = electron
 const windowSnapper = require('./window-snapper')
 
 let timerWindow, configWindow, fullscreenWindow
@@ -9,7 +10,7 @@ exports.createTimerWindow = () => {
     return
   }
 
-  let {width, height} = electron.screen.getPrimaryDisplay().workAreaSize
+  let { width, height } = electron.screen.getPrimaryDisplay().workAreaSize
   timerWindow = new electron.BrowserWindow({
     x: width - 220,
     y: height - 90,
@@ -81,12 +82,12 @@ exports.createFullscreenWindow = () => {
     return
   }
 
-  let {width, height} = electron.screen.getPrimaryDisplay().workAreaSize
-  fullscreenWindow = new electron.BrowserWindow({
+  const primaryDisplay = electron.screen.getPrimaryDisplay()
+  const { width, height } = primaryDisplay.bounds
+  fullscreenWindow = createAlwaysOnTopFullscreenInterruptingWindow({
     width,
     height,
     resizable: false,
-    alwaysOnTop: true,
     frame: false
   })
 
@@ -133,4 +134,18 @@ exports.setConfigState = data => {
     timerWindow.close()
     exports.createTimerWindow()
   }
+}
+
+function createAlwaysOnTopFullscreenInterruptingWindow(options) {
+  if (app.dock) {
+    // Mac OS: The window will be able to float above fullscreen windows too
+    app.dock.hide()
+  }
+  const window = new electron.BrowserWindow(options)
+  window.setAlwaysOnTop(true, 'screen-saver')
+  if (app.dock) {
+    // Mac OS: Show in dock again, window has been created
+    app.dock.show()
+  }
+  return window
 }

--- a/src/windows/windows.js
+++ b/src/windows/windows.js
@@ -137,15 +137,22 @@ exports.setConfigState = data => {
 }
 
 function createAlwaysOnTopFullscreenInterruptingWindow(options) {
+  return whileAppDockHidden(() => {
+    const window = new electron.BrowserWindow(options)
+    window.setAlwaysOnTop(true, 'screen-saver')
+    return window
+  })
+}
+
+function whileAppDockHidden(work) {
   if (app.dock) {
     // Mac OS: The window will be able to float above fullscreen windows too
     app.dock.hide()
   }
-  const window = new electron.BrowserWindow(options)
-  window.setAlwaysOnTop(true, 'screen-saver')
+  const result = work()
   if (app.dock) {
     // Mac OS: Show in dock again, window has been created
     app.dock.show()
   }
-  return window
+  return result
 }


### PR DESCRIPTION
Discussion in #11

# Why?

**In order** to be able to develop in fullscreen mode on Mac OS
**And** still see the mob timer and be interrupted by the fullscreen window to switch mobber
**We want** the fullscreen window to open on top of the fullscreen display or interrupt it by switching the active desktop

# How?

- Hide dock on window creation, which allows windows to float above/interrupt other fullscreen windows.
- Set alwaysOnTop-level to `screen-saver` for the fullscreen window to be on top of everything else.

# Tests

- [ ] Single screen Mac OSX Mojave
- [x] Single screen Windows 10
- [ ] Multiple connected screens