### PR TITLE
Ignore the package-lock.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 node_modules/
 *.log
 .DS_Store
+package-lock.json


### PR DESCRIPTION
The `package-lock.json` file that npm creates kept getting in my way. It needs to either be committed or ignored, and I prefer ignoring it.

I know that the file has been controversial in the past, so I'm open to hearing reasons why it should be committed instead.