### PR TITLE
Option to shuffle mobbers on startup

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,9 @@ app.on('ready', () => {
   timerState.loadState(statePersister.read())
   windows.setConfigState(timerState.getState())
   windows.createTimerWindow()
+  if (timerState.getState().shuffleMobbersOnStartup) {
+    timerState.shuffleMobbers()
+  }
 })
 
 function onTimerEvent(event, data) {

--- a/src/main.js
+++ b/src/main.js
@@ -44,6 +44,7 @@ ipc.on('setSnapThreshold', (event, threshold) => timerState.setSnapThreshold(thr
 ipc.on('setAlertSoundTimes', (event, alertSoundTimes) => timerState.setAlertSoundTimes(alertSoundTimes))
 ipc.on('setAlertSound', (event, alertSound) => timerState.setAlertSound(alertSound))
 ipc.on('setTimerAlwaysOnTop', (event, value) => timerState.setTimerAlwaysOnTop(value))
+ipc.on('setShuffleMobbersOnStartup', (event, value) => timerState.setShuffleMobbersOnStartup(value))
 
 app.on('window-all-closed', function() {
   if (process.platform !== 'darwin') {

--- a/src/state/timer-state.js
+++ b/src/state/timer-state.js
@@ -13,6 +13,7 @@ class TimerState {
     this.alertSound = null
     this.alertSoundTimes = []
     this.timerAlwaysOnTop = true
+    this.shuffleMobbersOnStartup = false
 
     this.createTimers(options.Timer || Timer)
   }
@@ -155,6 +156,11 @@ class TimerState {
     this.publishConfig()
   }
 
+  setShuffleMobbersOnStartup(value) {
+    this.shuffleMobbersOnStartup = value
+    this.publishConfig()
+  }
+
   shuffleMobbers() {
     this.mobbers.shuffleMobbers()
     this.publishConfig()
@@ -168,7 +174,8 @@ class TimerState {
       snapThreshold: this.snapThreshold,
       alertSound: this.alertSound,
       alertSoundTimes: this.alertSoundTimes,
-      timerAlwaysOnTop: this.timerAlwaysOnTop
+      timerAlwaysOnTop: this.timerAlwaysOnTop,
+      shuffleMobbersOnStartup: this.shuffleMobbersOnStartup
     }
   }
 
@@ -189,6 +196,7 @@ class TimerState {
     if (typeof state.timerAlwaysOnTop === 'boolean') {
       this.timerAlwaysOnTop = state.timerAlwaysOnTop
     }
+    this.shuffleMobbersOnStartup = !!state.shuffleMobbersOnStartup
   }
 }
 

--- a/src/windows/config/index.html
+++ b/src/windows/config/index.html
@@ -64,6 +64,12 @@
             Timer window floats above other windows
           </label>
         </div>
+        <div>
+          <label>
+            <input type="checkbox" id="shuffleMobbersOnStartup" class="settings-checkbox"/>
+            Shuffle mobbers on startup
+          </label>
+        </div>
       </div>
     </div>
     <script type="text/javascript">

--- a/src/windows/config/index.js
+++ b/src/windows/config/index.js
@@ -15,6 +15,7 @@ const replayAudioAfterSeconds = document.getElementById('replayAudioAfterSeconds
 const useCustomSoundCheckbox = document.getElementById('useCustomSound')
 const customSoundEl = document.getElementById('customSound')
 const timerAlwaysOnTopCheckbox = document.getElementById('timerAlwaysOnTop')
+const shuffleMobbersOnStartupCheckbox = document.getElementById('shuffleMobbersOnStartup')
 
 function createMobberEl(mobber) {
   const el = document.createElement('div')
@@ -90,6 +91,7 @@ ipc.on('configUpdated', (event, data) => {
   customSoundEl.value = data.alertSound
 
   timerAlwaysOnTopCheckbox.checked = data.timerAlwaysOnTop
+  shuffleMobbersOnStartupCheckbox.checked = data.shuffleMobbersOnStartup
 })
 
 minutesEl.addEventListener('change', () => {
@@ -178,4 +180,8 @@ useCustomSoundCheckbox.addEventListener('change', () => {
 
 timerAlwaysOnTopCheckbox.addEventListener('change', () => {
   ipc.send('setTimerAlwaysOnTop', timerAlwaysOnTopCheckbox.checked)
+})
+
+shuffleMobbersOnStartupCheckbox.addEventListener('change', () => {
+  ipc.send('setShuffleMobbersOnStartup', shuffleMobbersOnStartupCheckbox.checked)
 })

--- a/test/state/timer-state.specs.js
+++ b/test/state/timer-state.specs.js
@@ -167,6 +167,7 @@ describe('timer-state', () => {
       assert.strictEqual(event.data.alertSound, null)
       assert.deepStrictEqual(event.data.alertSoundTimes, [])
       assert.strictEqual(event.data.timerAlwaysOnTop, true)
+      assert.strictEqual(event.data.shuffleMobbersOnStartup, false)
     })
 
     it('should contain the mobbers if there are some', () => {
@@ -371,6 +372,15 @@ describe('timer-state', () => {
     })
   })
 
+  describe('when setting shuffle mobbers on startup', () => {
+    beforeEach(() => timerState.setShuffleMobbersOnStartup(true))
+
+    it('should publish a configUpdated event', () => {
+      var event = assertEvent('configUpdated')
+      assert.deepStrictEqual(event.data.shuffleMobbersOnStartup, true)
+    })
+  })
+
   describe('getState', () => {
     describe('when getting non-default state', () => {
       beforeEach(() => {
@@ -382,6 +392,7 @@ describe('timer-state', () => {
         timerState.setAlertSound(expectedAlertSound)
         timerState.setAlertSoundTimes(expectedAlertSoundTimes)
         timerState.setTimerAlwaysOnTop(expectedTimerAlwaysOnTop)
+        timerState.setShuffleMobbersOnStartup(expectedShuffleMobbersOnStartup)
 
         result = timerState.getState()
       })
@@ -418,6 +429,10 @@ describe('timer-state', () => {
         assert.strictEqual(result.timerAlwaysOnTop, expectedTimerAlwaysOnTop)
       })
 
+      it('should get the correct shuffle mobbers on startup', () => {
+        assert.strictEqual(result.shuffleMobbersOnStartup, expectedShuffleMobbersOnStartup)
+      })
+
       let result = {}
       let expectedJack = { name: 'jack' }
       let expectedJill = { name: 'jill' }
@@ -427,6 +442,7 @@ describe('timer-state', () => {
       let expectedAlertSound = 'alert.mp3'
       let expectedAlertSoundTimes = [0, 15]
       let expectedTimerAlwaysOnTop = false
+      let expectedShuffleMobbersOnStartup = true
     })
 
     describe('when getting default state', () => {
@@ -438,6 +454,7 @@ describe('timer-state', () => {
       it('should have a null alert sound', () => assert(result.alertSound === null))
       it('should have an empty array of alert sound times', () => assert.deepStrictEqual(result.alertSoundTimes, []))
       it('should have a default timerAlwaysOnTop', () => assert.deepStrictEqual(result.timerAlwaysOnTop, true))
+      it('should have a default shuffleMobbersOnStartup', () => assert.strictEqual(result.shuffleMobbersOnStartup, false))
 
       let result = {}
     })
@@ -470,7 +487,8 @@ describe('timer-state', () => {
           snapThreshold: 22,
           alertSound: 'bell.mp3',
           alertSoundTimes: [2, 3, 5, 8],
-          timerAlwaysOnTop: false
+          timerAlwaysOnTop: false,
+          shuffleMobbersOnStartup: true
         }
 
         timerState.loadState(state)
@@ -485,6 +503,7 @@ describe('timer-state', () => {
       it('should load alertSound', () => assert.strictEqual(result.alertSound, state.alertSound))
       it('should load alertSoundTimes', () => assert.deepStrictEqual(result.alertSoundTimes, [2, 3, 5, 8]))
       it('should load timerAlwaysOnTop', () => assert.strictEqual(result.timerAlwaysOnTop, state.timerAlwaysOnTop))
+      it('should load shuffleMobbersOnStartup', () => assert.strictEqual(result.shuffleMobbersOnStartup, state.shuffleMobbersOnStartup))
 
       let result = {}
       let state = {}
@@ -504,6 +523,7 @@ describe('timer-state', () => {
       it('should have a null alertSound', () => assert.strictEqual(result.alertSound, null))
       it('should have an empty array of alertSoundTimes', () => assert.deepStrictEqual(result.alertSoundTimes, []))
       it('should have a default timerAlwaysOnTop', () => assert.strictEqual(result.timerAlwaysOnTop, true))
+      it('should have a default shuffleMobbersOnStartup', () => assert.strictEqual(result.shuffleMobbersOnStartup, false))
 
       let result = {}
     })

--- a/test/state/timer-state.specs.js
+++ b/test/state/timer-state.specs.js
@@ -372,7 +372,7 @@ describe('timer-state', () => {
 
   describe('getState', () => {
     describe('when getting non-default state', () => {
-      before(() => {
+      beforeEach(() => {
         timerState.addMobber(expectedJack)
         timerState.addMobber(expectedJill)
         timerState.setSecondsPerTurn(expectedSecondsPerTurn)
@@ -429,7 +429,7 @@ describe('timer-state', () => {
     })
 
     describe('when getting default state', () => {
-      before(() => (result = timerState.getState()))
+      beforeEach(() => (result = timerState.getState()))
 
       it('should get no mobbers', () => assert(result.mobbers.length === 0))
       it('should have a default secondsPerTurn greater than zero', () => assert(result.secondsPerTurn > 0))

--- a/test/state/timer-state.specs.js
+++ b/test/state/timer-state.specs.js
@@ -166,6 +166,7 @@ describe('timer-state', () => {
       assert.strictEqual(event.data.snapThreshold, 25)
       assert.strictEqual(event.data.alertSound, null)
       assert.deepStrictEqual(event.data.alertSoundTimes, [])
+      assert.strictEqual(event.data.timerAlwaysOnTop, true)
     })
 
     it('should contain the mobbers if there are some', () => {


### PR DESCRIPTION
This feature adds a checkbox option (defaults off) to shuffle mobbers when the timer starts up. My thinking is that this feature would make it easier for teams to change up their mobbing order more frequently, but without having to go click the shuffle button manually.

Teams that want to be more stable just leave the option off and can manually click the shuffle button as desired.