### PR TITLE
Move away from SetInterval to Date.now

### DIFF
--- a/src/state/timer-state.js
+++ b/src/state/timer-state.js
@@ -47,7 +47,7 @@ class TimerState {
 
   dispatchTimerChange(secondsRemaining) {
     this.callback('timerChange', {
-      secondsRemaining,
+      secondsRemaining: secondsRemaining < 0 ? 0 : secondsRemaining,
       secondsPerTurn: this.secondsPerTurn
     })
   }

--- a/src/state/timer.js
+++ b/src/state/timer.js
@@ -2,15 +2,22 @@ class Timer {
   constructor(options, callback) {
     this.rateMilliseconds = options.rateMilliseconds || 1000
     this.time = options.time || 0
-    this.change = options.countDown ? -1 : 1
+    this.timeDelta = 0
+    this.countDown = options.countDown === true
     this.callback = callback
+    this.startingTime = null
   }
 
-  start() {
+  start(now = Date.now) {
+    this.startingTime = now()
+
     if (!this.interval) {
       this.interval = setInterval(() => {
-        this.time += this.change
-        this.callback(this.time)
+        const secondsPassed = Math.floor((now() - this.startingTime) / 1000)
+        this.timeDelta = secondsPassed
+        const secondsRemaining = this.time - secondsPassed
+
+        this.callback(this.countDown ? secondsRemaining : secondsPassed + this.time)
       }, this.rateMilliseconds)
     }
   }
@@ -20,10 +27,16 @@ class Timer {
       clearInterval(this.interval)
       this.interval = null
     }
+    this.countDown
+      ? (this.time = this.time - this.timeDelta)
+      : (this.time += this.timeDelta)
+    this.timeDelta = 0
   }
 
-  reset(value) {
+  reset(value, now = Date.now) {
     this.time = value
+    this.timeDelta = 0
+    this.startingTime = now()
   }
 }
 

--- a/test/state/timer.specs.js
+++ b/test/state/timer.specs.js
@@ -8,6 +8,11 @@ describe('Timer', () => {
   let callbacks
   let clock
 
+  const mockDateNow = () => {
+    let calls = 0
+    return () => { calls++; return calls * 1000 }
+  }
+
   let createTimer = () => {
     timer = new Timer(timerOptions, x => callbacks.push(x))
   }
@@ -34,8 +39,8 @@ describe('Timer', () => {
         assert.strictEqual(timer.time, timerOptions.time)
       })
 
-      it('should have a change value based on the specified countDown', () => {
-        assert.strictEqual(timer.change, -1)
+      it('should know if it is counting up or down based on the specified countDown', () => {
+        assert.strictEqual(timer.countDown, true)
       })
     })
 
@@ -53,15 +58,15 @@ describe('Timer', () => {
         assert.strictEqual(timer.time, 0)
       })
 
-      it('should have the default change value', () => {
-        assert.strictEqual(timer.change, 1)
+      it('should have the default countDown value', () => {
+        assert.strictEqual(timer.countDown, false)
       })
     })
   })
 
   describe('start', () => {
     it('should generate callbacks when counting down', () => {
-      timer.start()
+      timer.start(mockDateNow())
       clock.tick(50)
       assert.strictEqual(callbacks.join(','), '49,48')
     })
@@ -69,7 +74,7 @@ describe('Timer', () => {
     it('should generate callbacks when counting up', () => {
       timerOptions.countDown = false
       createTimer()
-      timer.start()
+      timer.start(mockDateNow())
       clock.tick(50)
       assert.strictEqual(callbacks.join(','), '51,52')
     })
@@ -77,7 +82,7 @@ describe('Timer', () => {
 
   describe('pause', () => {
     it('should stop further callbacks from occuring', () => {
-      timer.start()
+      timer.start(mockDateNow())
       clock.tick(50)
       timer.pause()
       clock.tick(100)
@@ -92,9 +97,10 @@ describe('Timer', () => {
     })
 
     it('should set a new time value when the timer is running', () => {
-      timer.start()
+      const mockedNow = mockDateNow()
+      timer.start(mockedNow)
       clock.tick(50)
-      timer.reset(20)
+      timer.reset(20, mockedNow)
       clock.tick(40)
       assert.strictEqual(callbacks.join(','), '49,48,19,18')
     })


### PR DESCRIPTION
When offscreen (IE in another macOs desktop), the mob timer accuracy tends to drift, making turns last several minutes longer than they should.

This pull request moves away from trusting the SetInterval callback to be called every second, and instead relies on computed time differences using Javascript's Date object.