### PR TITLE
Add note about liveshare extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Pluralsight Mob Timer
 A cross-platform timer built on [Electron](http://electron.atom.io/)
-for doing [Mob Programming](http://mobprogramming.org/)
+for doing [Mob Programming](http://mobprogramming.org/).
+
+**Heads up!** There is also an [extension](https://marketplace.visualstudio.com/items?itemName=pluralsight.live-share-mob-timer)
+for Visual Studio Code's Live Share experience.
+This is a different, standalone, project.
 
 ![Example Timer Image](timer-example.png)
 


### PR DESCRIPTION
This PR adds a note to the top of the Readme to alert folks of the difference between this project and the VS Code Live Share extension. That extension's repo is not (yet) publicly accessible, so we link instead to the VS Code marketplace.